### PR TITLE
fix: link path problem

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -59,12 +59,9 @@ module.exports = class Printer {
     }
 
     if (category && graphLQLNamedType) {
-      return `[\`${name}\`](${path.join(
-        this.linkRoot,
-        this.baseURL,
-        category,
-        toSlug(graphLQLNamedType),
-      )})`;
+      return `[\`${name}\`](${path
+        .posix.join(this.linkRoot, this.baseURL, category, toSlug(graphLQLNamedType))
+      })`;
     } else {
       return `\`${name}\``;
     }


### PR DESCRIPTION
Fixed a problem where the link path separator would be a backslash instead of a slash on Windows.

`[CustomerCreateInput!](\docs\api\admin\graphql\inputs\customer-create-input)` -> `[CustomerCreateInput!](/docs/api/admin/graphql/inputs/customer-create-input)`