### PR TITLE
Fix compilation error for @specifiedBy directives by adding a newline

### DIFF
--- a/src/lib/printer.js
+++ b/src/lib/printer.js
@@ -209,8 +209,10 @@ module.exports = class Printer {
 
   printSpecification(type) {
     if (type.specifiedByUrl) {
+      // Needs newline between "export const specifiedByLinkCss" and markdown header to prevent compilation error in docusaurus
       return `
 export const specifiedByLinkCss = { fontSize:'1.5em', paddingLeft:'4px' };
+
 ${HEADER_SECTION_LEVEL} Specification<a className="link" style={specifiedByLinkCss} target="_blank" href="${type.specifiedByUrl}" title="Specified by ${type.specifiedByUrl}">⎘</a>\n\n
       `;
     }


### PR DESCRIPTION
# Description (TL;DR)
When using Docusaurus 2.0.0, a compilation error occurs after generating docs for a scalar with a `@specifiedBy` directive, because a newline is missing between `specifiedByLinkCss` and the "Specification" header.

This PR simply adds the missing newline.

(I omitted to make an issue, since the fix is so simple. Hope it is okay 😄)

# Details

Error message produced:
```
SyntaxError: [..]docs/graphql/scalars/json.mdx: Unexpected token (2:0)
  1 | export const specifiedByLinkCss = { fontSize:'1.5em', paddingLeft:'4px' };
> 2 | ### Specification<a className="link" style={specifiedByLinkCss} target="_blank" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf" title="Specified by http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">⎘</a>
```

The graphql schema looks like this:
```graphql
"""
The `JSON` scalar type represents JSON values as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
"""
scalar JSON @specifiedBy(url: "http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf")
```

and is compiled to:
```mdx
(header info)...

export const specifiedByLinkCss = { fontSize:'1.5em', paddingLeft:'4px' };
### Specification<a className="link" style={specifiedByLinkCss} target="_blank" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf" title="Specified by http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">⎘</a>
```

With the fix, the schema is now now compiled to:
```mdx
(header info)...

export const specifiedByLinkCss = { fontSize:'1.5em', paddingLeft:'4px' };

### Specification<a className="link" style={specifiedByLinkCss} target="_blank" href="http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf" title="Specified by http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf">⎘</a>
```